### PR TITLE
Add a new gene "capO" to the database

### DIFF
--- a/src/args_oap/db/single-component_structure.txt
+++ b/src/args_oap/db/single-component_structure.txt
@@ -1,4 +1,5 @@
 gene	subtype	type
+capO	capO	chloramphenicol
 L06156.1.gene1.p01	aminoglycoside__AAC(2')-Ia	aminoglycoside
 U41471.1.gene1.p01	aminoglycoside__AAC(2')-Ib	aminoglycoside
 YP_001848841	aminoglycoside__AAC(2')-Ic	aminoglycoside


### PR DESCRIPTION
capO is a new gene which required to be added to the database.